### PR TITLE
PI-3409: ensure back/MENU on a credited Innovid ad completes it

### DIFF
--- a/TruexSimpleReferenceAppCocoa/ViewController.m
+++ b/TruexSimpleReferenceAppCocoa/ViewController.m
@@ -113,8 +113,4 @@ static int const MidrollAdBreakDimensionValue = 2;
     [self.player play];
 }
 
--(void) onUserCancelStream {
-    [self dismissViewControllerAnimated:YES completion:nil];
-}
-
 @end


### PR DESCRIPTION
Jira: [PI-3409](https://infillion.atlassian.net/browse/PI-3409): AMC tvOS Play Button Issue

Ensure that a credited Innovid ad completes normally on MENU/back actions.

[PI-3409]: https://infillion.atlassian.net/browse/PI-3409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ